### PR TITLE
[TASK] DPL-158: Streamline package bundling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 /Build/ export-ignore
 /Tests/ export-ignore
 /packages/ export-ignore
+/contrib/Libraries/ export-ignore
 
 # Files
 .editorconfig export-ignore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,38 +49,11 @@ jobs:
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
 
-      - name: Prepare vendor folder and autoload configuration for TER upload
-        shell: bash
-        run: |
-          rm -rf vendor composer.lock composer.json.orig composer.json.pretty \
-            && mv composer.json composer.json.orig \
-              && composer init -n \
-                --type=project \
-                --license='GPL-2.0-or-later' \
-                --name=release/draft \
-                --description empty \
-                --author='release' \
-              && composer config allow-plugins.php-http/discovery true \
-              && composer require "deeplcom/deepl-php":"$( cat composer.json.orig | jq -r '.require."deeplcom/deepl-php"' )" \
-              && rm -rf composer.lock \
-                vendor/composer \
-                vendor/nyholm \
-                vendor/php-http/multipart-stream-builder \
-                vendor/psr \
-                vendor/symfony \
-                vendor/autoload.php \
-                vendor/bin \
-              && mv vendor contrib \
-              && cat <<< $(jq --indent 4 '."autoload"."psr-4" += {"DeepL\\": "contrib/deeplcom/deepl-php/src"}' composer.json.orig) > composer.json.pretty \
-              && cat <<< $(jq --indent 4 '."autoload"."psr-4" += {"Http\\Discovery\\": "contrib/php-http/discovery/src"}' composer.json.pretty) > composer.json.pretty \
-              && rm -rf composer.json \
-              && mv composer.json.pretty composer.json \
-              && rm -rf composer.json.orig \
-              && composer config "version" "${{ env.version }}" \
-              && composer config "extra"."typo3/cms"."version" "${{ env.version }}"
-
       - name: Install tailor
         run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
+
+      - name: Install contrib libraries
+        run: composer install -d contrib
 
       # Note that step will fail when `env.version` does not match the `ext_emconf.php` version.
       - name: Create local TER package upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .Build
 !.Build/Web/.gitkeep
 .ddev/docker-compose.tempfs.yaml
-composer.lock
+/composer.lock
 composer.json.testing
 composer.json.orig
 composer.json.pretty

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ We prefer composer installation:
 composer require 'web-vision/deeplcom-deepl-php':'1.*.*@dev'
 ```
 
+## Set `deeplcom/deepl-php` version
+
+> [!IMPORTANT]
+> It's important to use these commands to have the bundled contrib folder
+> providing the correct version, otherwise wrong version would be shipped
+> and used in classic mode instances.
+
+```bash
+PACKAGE_VERSION='1.18.0' ; \
+  composer require "deeplcom/deepl-php:${PACKAGE_VERSION}" && \
+  composer require -d contrib "deeplcom/deepl-php:${PACKAGE_VERSION}" && \
+  composer config "extra"."typo3/cms"."version" "${PACKAGE_VERSION}-dev" && \
+  echo "${PACKAGE_VERSION}-dev" > VERSION && \
+  sed -i "s/^  PACKAGE_VERSION.*/  PACKAGE_VERSION=\"${DEV_VERSION}\"/" README.md && \
+  git add . && \
+  git commit -m "[TASK] Set 'deeplcom/deepl-php' to '${PACKAGE_VERSION}'"
+```
+
 ## Create a release (maintainers only)
 
 Prerequisites:
@@ -51,7 +69,8 @@ Prerequisites:
 ```shell
 echo '>> Prepare release pull-request' ; \
   RELEASE_BRANCH='main' ; \
-  RELEASE_VERSION='1.0.0' ; \
+  RELEASE_VERSION='1.18.0' ; \
+  DEV_VERSION='1.18.1' ; \
   git checkout main && \
   git fetch --all && \
   git pull --rebase && \
@@ -60,9 +79,17 @@ echo '>> Prepare release pull-request' ; \
   tailor set-version ${RELEASE_VERSION} && \
   composer config "extra"."typo3/cms"."version" "${RELEASE_VERSION}" && \
   echo "${RELEASE_VERSION}" > VERSION && \
+  sed -i "s/^  RELEASE_VERSION.*/  RELEASE_VERSION=\"${RELEASE_VERSION}\"/" README.md && \
+  sed -i "s/^  DEV_VERSION.*/  DEV_VERSION=\"${DEV_VERSION}\"/" README.md && \
   git add . && \
   git commit -m "[RELEASE] ${RELEASE_VERSION}" && \
   git tag ${RELEASE_VERSION} && \
   git push && \
-  git push --tags
+  git push --tags \
+  tailor set-version ${DEV_VERSION} && \
+  composer config "extra"."typo3/cms"."version" "${DEV_VERSION}-dev" && \
+  echo "${DEV_VERSION}-dev" > VERSION && \
+  git add . && \
+  git commit -m "[TASK] Set dev version ${DEV_VERSION}-dev" && \
+  git push
 ```

--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,7 @@
 			"app-dir": ".Build",
 			"Package": {
 				"providesPackages": {
-					"deeplcom/deepl-php": "",
-					"php-http/discovery": ""
+					"deeplcom/deepl-php": "contrib/Libraries"
 				}
 			},
 			"version": "1.17.1"

--- a/contrib/composer.json
+++ b/contrib/composer.json
@@ -1,0 +1,32 @@
+{
+	"name": "web-vision/deeplcom-deepl-php-lib",
+	"license": "GPL-2.0-or-later",
+	"config": {
+		"vendor-dir": "Libraries",
+		"preferred-install": {
+			"*": "dist"
+		},
+		"classmap-authoritative": true,
+		"platform": {
+			"php": "8.1.0"
+		},
+		"allow-plugins": {
+			"php-http/discovery": false
+		}
+	},
+	"require": {
+		"php": "^8.1 || ^8.2 || ^8.3 || ^8.4 || ^8.5",
+		"deeplcom/deepl-php": "1.17.0"
+	},
+	"replace": {
+		"psr/log": "*",
+		"psr/http-message": "*",
+		"psr/http-client": "*",
+		"php-http/multipart-stream-builder": "*"
+	},
+	"provide": {
+		"psr/http-client-implementation": "1.0",
+		"psr/http-factory-implementation": "1.0",
+		"psr/http-message-implementation": "1.0"
+	}
+}

--- a/contrib/composer.lock
+++ b/contrib/composer.lock
@@ -1,0 +1,166 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "33c962f596efbc617d0ffd1d21459eee",
+    "packages": [
+        {
+            "name": "deeplcom/deepl-php",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DeepLcom/deepl-php.git",
+                "reference": "ab19088afb40dd4c1b8ff8f5a13172e29a824b7d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DeepLcom/deepl-php/zipball/ab19088afb40dd4c1b8ff8f5a13172e29a824b7d",
+                "reference": "ab19088afb40dd4c1b8ff8f5a13172e29a824b7d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=7.3.0",
+                "php-http/discovery": "^1.18",
+                "php-http/multipart-stream-builder": "^1.3",
+                "psr/http-client": "^1.0",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "guzzlehttp/guzzle": "^7.7.0",
+                "php-mock/php-mock-phpunit": "^2.6",
+                "phpunit/phpunit": "^9",
+                "ramsey/uuid": "^4.2",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "DeepL SE",
+                    "email": "open-source@deepl.com"
+                }
+            ],
+            "description": "Official DeepL API Client Library",
+            "keywords": [
+                "api",
+                "deepl",
+                "translation",
+                "translator"
+            ],
+            "support": {
+                "issues": "https://github.com/DeepLcom/deepl-php/issues",
+                "source": "https://github.com/DeepLcom/deepl-php/tree/v1.17.0"
+            },
+            "time": "2026-03-26T19:17:46+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.1 || ^8.2 || ^8.3 || ^8.4 || ^8.5"
+    },
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.1.0"
+    },
+    "plugin-api-version": "2.9.0"
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,15 @@
+<?php
+
+use TYPO3\CMS\Core\Core\Environment;
+
+defined('TYPO3') or die();
+
+// Compatibility layer to provide autoloading for bundled libraries in classic mode instances prior
+// to TYPO3 v14.3, which will use `extra.typo3/cms.Package.providesPackage` from the `composer.json`
+// to add autoloading early in TYPO3 bootstrap.
+// Having the contrib library included in the git repo allows checking out the extension from git
+// in classic mode installations to `typo3conf/ext` and still have the required library provided.
+// @todo typo3/cms:>=14.3 Remove this compatibility layer providing contrib library autoloading.
+if (!class_exists(\DeepL\DeepLClient::class)) {
+    require Environment::getExtensionsPath() . '/deeplcom_deeplphp/contrib/Libraries/autoload.php';
+}


### PR DESCRIPTION
TYPO3 v14.3 introduces automatic autoloading for bundled
Composer vendor directories in classic mode installations
via the new Composer option `providesPackages`, e.g.:

```json
{
  "extra": {
    "typo3/cms": {
      "Package": {
        "providesPackages": {
          "vendor/package-name": "custom_vendor_folder"
        }
      }
    }
  }
}
```

This change aligns package bundling with this mechanism
and replaces the previous "add autoload namespaces"
approach. The following steps were implemented:

* Added `contrib/` directory with a `composer.json`
  requiring the bundled library. Uses `replaces` to
  prevent installation of transitive packages that
  are not intended to be bundled.

* Introduced `ext_localconf.php` with a conditional
  require for the bundled Composer autoloader. Acts
  as a backward compatibility layer for older TYPO3
  versions in classic mode if classes are not yet
  autoloaded.

* Updated `README.md` with instructions for setting
  a specific bundled package version. Requires
  changes in both the root `composer.json` and
  `contrib/composer.json`, followed by installation
  to update the files.

* Removed bundling step in `publish` GitHub action
  workflow.

> [!NOTE]
> This has been manual tested in classic mode instance
> creating a tailor TER package and manually uploading
> it using `EXT:extensionmanager`. The modern bundle
> strategy has been verified that way.
